### PR TITLE
feat: add key listeners for restart/next/retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,19 @@ A typing test inside your editor!
 ## Contributions
 
 Pull requests and issues are welcome! Feedback is appreciated!
+
+### Development Setup
+
+When running for the first time, the extension needs the emitted `webview/index.js` file to exist, so compile it first:
+
+```sh
+npm run compile:webview
+```
+
+When making changes to the [webview/](webview/), make sure to recompile before rerunning the extension too:
+
+```sh
+npm run compile:webview
+```
+
+Then as usual, open [src/extension.ts](src/extension.ts) and run the command **Debug: Start Debugging** (<kbd>F5</kbd>) to launch the extension locally in the **Extension Development Host**.

--- a/src/modules/webviewPanel.ts
+++ b/src/modules/webviewPanel.ts
@@ -224,7 +224,7 @@ export class TypingTestPanel {
                     <div id="start-text"></div>
                 </div>
               <button type="button" id="restart-button" class="btn btn-minimal" data-bs-toggle="tooltip"
-                  data-bs-placement="bottom" data-bs-title="restart">
+                  data-bs-placement="bottom" data-bs-title="restart (Shift+Enter)">
                   <i class="bi bi-arrow-clockwise"></i>
               </button>
             </div>
@@ -263,13 +263,13 @@ export class TypingTestPanel {
                 <div class="row">
                     <div class="col">
                         <button type="button" id="next-button" class="btn btn-minimal" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" data-bs-title="next">
+                            data-bs-placement="bottom" data-bs-title="next (Enter)">
                             <i class="bi bi-chevron-right"></i>
                         </button>
                     </div>
                     <div class="col">
                         <button type="button" id="retry-button" class="btn btn-minimal" data-bs-toggle="tooltip"
-                            data-bs-placement="bottom" data-bs-title="retry">
+                            data-bs-placement="bottom" data-bs-title="retry (Shift+Enter)">
                             <i class="bi bi-arrow-repeat"></i>
                         </button>
                     </div>

--- a/webview/src/index.ts
+++ b/webview/src/index.ts
@@ -7,9 +7,14 @@ const vscode = acquireVsCodeApi();
 
 // tooltips
 const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+// @ts-expect-error
 const _ = [...tooltipTriggerList].map(tooltipTriggerEl => new Tooltip(tooltipTriggerEl))
 
 let currentPassage: string[];
+
+function startNextTest() {
+  getNewPassage(getTypingTestConfig());
+}
 
 document.getElementById("restart-button")?.addEventListener("click", (_) => {
   resetOrRestartTest();
@@ -20,9 +25,47 @@ document.getElementById("retry-button")?.addEventListener("click", (_) => {
 });
 
 document.getElementById("next-button")?.addEventListener("click", (_) => {
-  getNewPassage(getTypingTestConfig());
+  startNextTest();
 });
 
+document.addEventListener("keydown", (event) => {
+  // Key mappings:
+  //
+  //    - ENTER => equivalent to clicking next-button
+  //    - SHIFT-ENTER => equivalent to clicking restart-button OR retry-button
+  //
+  // For consistency, we check that the respective button is available for the
+  // key bind to be considered active. This is to respect the existing UI where
+  // certain buttons are only available on certain "pages", which are
+  // ever-present in the DOM but take turns being visible. This hopefully makes
+  // any updates to such buttons automatically propagate to this listener.
+
+  function isElementAvailable(id: string): boolean {
+    const element = document.getElementById(id);
+    if (!element) {
+      return false;
+    }
+    // The buttons may not be directly `.hidden` (but rather indirectly e.g.
+    // next-button via the results page), so we use `.offsetParent` instead:
+    // https://stackoverflow.com/a/21696585/14226122.
+    return element.offsetParent !== null;
+  }
+
+  const { key, shiftKey } = event;
+  if (key === "Enter" && shiftKey && isElementAvailable("restart-button")) {
+    console.log("Restarting test via keybind");
+    resetOrRestartTest();
+  }
+  if (key === "Enter" && shiftKey && isElementAvailable("retry-button")) {
+    console.log("Retrying test via keybind");
+    resetOrRestartTest();
+  }
+  if (key === "Enter" && !shiftKey && isElementAvailable("next-button")) {
+    console.log("Moving on to next test via keybind");
+    startNextTest();
+  }
+  // Other potential key mappings...
+});
 
 export function getNewPassage(config: TypingTestConfig) {
   console.log('get new passage');


### PR DESCRIPTION
Targeted extension version: **1.0.0**

### Motivation

Currently, one needs to **click** icons in the webview to restart/next/retry the type test. In an environment where user workflow is already almost entirely dependent on the keyboard, this seems a bit interruptive. As a type tester extension (within an _editor_ no less), it makes sense to minimize the amount of mouse input needed. Not only is this a nice quality-of-life feature for the target audience, it also automatically improves **accessibility**.
 
### Changes

This PR adds the following key binds to the **webview**, as [`keydown` events](https://developer.mozilla.org/en-US/docs/Web/API/Element/keydown_event) on the root `document` node:

- <kbd>Enter</kbd>: Equivalent to clicking the `next` button (currently on the results page).
- <kbd>Shift+Enter</kbd>: Equivalent to clicking the `restart` (currently on the test page) or `retry` (currently on the results page) buttons.

To improve UX, the **tooltip** of the restart/next/retry buttons have also been edited to display their respective keybind on hover.

<kbd>Enter</kbd> and <kbd>Shift+Enter</kbd> seemed like reasonable defaults to me. To avoid key bind conflicts, I deliberately chose combinations that would only be used in an editor setting (which the type test emulates) while also not being the actual characters to type. Feel free to change them to others.

### Verification

You can manually verify the behavior by testing the full Cartesian product of states:

- During a test, hit <kbd>Enter</kbd>. It shouldn't do anything.
- When viewing results, hit <kbd>Enter</kbd>. It should bring you to a new test with a different prompt.
- During a test, hit <kbd>Shift+Enter</kbd>. It should restart the test with the same prompt.
- When viewing results, hit <kbd>Shift+Enter</kbd>. It should retry the test with the same prompt.
 
### Future Work

At the moment, these key binds are _hard-coded_. Future work could be done to make them configurable. I recall you should be able to do something like:

- Instead of making them event listeners on the webview itself, define **commands** (like `key-monkey.start` for starting the webview in the first place) for the restart/next/retry actions. This should automatically make them available for key binding within VS Code itself (<kbd>Ctrl+K Ctrl+S</kbd>).
  - Reasonable defaults (like <kbd>Enter</kbd> etc.) could be set as their defaults, with a **When** clause that restricts listening to the webview to avoid conflicts.
- Make those commands dispatch **messages** to the webview, which you can hook up to the backend routines `resetOrRestartTest()`/`startNextTest()`.
- Query the user-defined keyboard shortcut assigned to the commands to dynamically update the button tooltips with the shortcuts' representations.

Of course, that's a lot of work and rearchitecting for a small feature, so feel free to defer it.